### PR TITLE
Make RaiseResponse middleware compatible with Django 1.10+

### DIFF
--- a/raiseresponse/middlewares.py
+++ b/raiseresponse/middlewares.py
@@ -2,9 +2,13 @@
 from django.template import TemplateSyntaxError
 
 from .utils import ResponseError
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
 
-class RaiseResponse:
+class RaiseResponse(MiddlewareMixin):
     """
     Processes exceptions, returning a response if it's the case or raising
     the exception.


### PR DESCRIPTION
Hi there, here is a small patch to make django-raise-response work with Django version 1.10 and later, while maintaining retro-compatibility with older versions.
The middleware system got updated in v1.10, now middlewares need to inherit from MiddlewareMixin.
Successfully tested with v1.11.